### PR TITLE
Replace the deprecated .iteritems() with .items()

### DIFF
--- a/run_strong_full.py
+++ b/run_strong_full.py
@@ -104,7 +104,7 @@ def main():
     if(len(sys.argv) < 2):
         print ("Usage: python run.py application")
         print ("Applications available: ")
-        for key, value in applications.iteritems():
+        for key, value in applications.items():
             print (key )
         print ("All")
 
@@ -112,7 +112,7 @@ def main():
         cmd = sys.argv[1]
         print ("Application to run is: " + cmd )
         if cmd == "All":
-            for key, value in applications.iteritems():
+            for key, value in applications.items():
                 run(key)
                 os.chdir(rootdir)
         else:

--- a/run_strong_rank.py
+++ b/run_strong_rank.py
@@ -115,7 +115,7 @@ def main():
     if(len(sys.argv) < 2):
         print ("Usage: python run.py application")
         print ("Applications available: ")
-        for key, value in applications.iteritems():
+        for key, value in applications.items():
             print (key )
         print ("All")
 
@@ -123,7 +123,7 @@ def main():
         cmd = sys.argv[1]
         print ("Application to run is: " + cmd )
         if cmd == "All":
-            for key, value in applications.iteritems():
+            for key, value in applications.items():
                 run(key)
                 os.chdir(rootdir)
         else:

--- a/run_weak.py
+++ b/run_weak.py
@@ -155,7 +155,7 @@ def main():
     if(len(sys.argv) < 2):
         print ("Usage: python run.py application")
         print ("Applications available: ")
-        for key, value in applications.iteritems():
+        for key, value in applications.items():
             print (key )
         print ("All")
 
@@ -163,7 +163,7 @@ def main():
         cmd = sys.argv[1]
         print ("Application to run is: " + cmd )
         if cmd == "All":
-            for key, value in applications.iteritems():
+            for key, value in applications.items():
                 run(key)
                 os.chdir(rootdir)
         else:


### PR DESCRIPTION
The `.iteritems()` method was [removed](https://docs.python.org/3/library/2to3.html#2to3fixer-dict)
in Python 3. The direct replacement is `.items()` (which is
backwards-compatible with Python 2).

This change means that the execution scripts `run_*.py` fail on
Python 3. This commit provides Python 3 compatibility without
compromising Python 2 execution.

See, for reference:
  - saltstack-formulas/openssh-formula#48
  - https://stackoverflow.com/questions/10458437/what-is-the-difference-between-dict-items-and-dict-iteritems-in-python2