### PR TITLE
bs_bug_fix: Fix unaligned MRAM reads and boundary case handlings in BS benchmark

### DIFF
--- a/BS/dpu/task.c
+++ b/BS/dpu/task.c
@@ -79,8 +79,6 @@ int main_kernel1() {
     mram_read((__mram_ptr void const *) current_mram_block_addr_query, &searching_for, 8);
     current_mram_block_addr_query += 8;
 
-    bool end = false;
-
     // Initialize input vector boundaries
     start_mram_block_addr_A    = (uint32_t) DPU_MRAM_HEAP_POINTER;
     start_mram_block_addr_aux  = start_mram_block_addr_A;
@@ -101,17 +99,15 @@ int main_kernel1() {
       // Boundary check
       if(current_mram_block_addr_A < (start_mram_block_addr_A + BLOCK_SIZE))
       {
-        //end = true;
-	// find (start_mram_block_addr_A, start_mram_block_addr_A + BLOCK_SIZE)
+	// Search inside (start_mram_block_addr_A, start_mram_block_addr_A + BLOCK_SIZE)
         mram_read((__mram_ptr void const *) start_mram_block_addr_A, cache_A, BLOCK_SIZE);
         found = search(cache_A, searching_for, BLOCK_SIZE);
 
         if(found > -1)
         {
           result->found = found + (start_mram_block_addr_A - start_mram_block_addr_aux) / sizeof(DTYPE);
-	  printf("Tasklet %d has found %lld\n", me(), result->found + 1);
         }
-	// find (start_mram_block_addr_A + BLOCK_SIZE, end_mram_block_addr_A)
+	// Search inside (start_mram_block_addr_A + BLOCK_SIZE, end_mram_block_addr_A)
 	else
 	{
 	  size_t remain_bytes_to_search = end_mram_block_addr_A - (start_mram_block_addr_A + BLOCK_SIZE);
@@ -121,7 +117,6 @@ int main_kernel1() {
 	  if(found > -1)
           {
             result->found = found + (start_mram_block_addr_A + BLOCK_SIZE - start_mram_block_addr_aux) / sizeof(DTYPE);
-	    printf("Tasklet %d has found %lld\n", me(), result->found + 1);
           }
 	  else
 	  {
@@ -141,7 +136,6 @@ int main_kernel1() {
       if(found > -1)
       {
         result->found = found + (current_mram_block_addr_A - start_mram_block_addr_aux) / sizeof(DTYPE);
-	printf("Tasklet %d has found %lld\n", me(), result->found + 1);
         break;
       }
 

--- a/BS/dpu/task.c
+++ b/BS/dpu/task.c
@@ -92,11 +92,12 @@ int main_kernel1() {
     mram_read((__mram_ptr void const *) current_mram_block_addr_A, cache_aux_A, BLOCK_SIZE);
     mram_read((__mram_ptr void const *) (end_mram_block_addr_A - BLOCK_SIZE * sizeof(DTYPE)),   cache_aux_B, BLOCK_SIZE);
 
-    current_mram_block_addr_A = (start_mram_block_addr_A + end_mram_block_addr_A) / 2;
-    current_mram_block_addr_A &= WORD_MASK;
-
     while(1)
     {
+      // Locate the address of the mid mram block
+      current_mram_block_addr_A = (start_mram_block_addr_A + end_mram_block_addr_A) / 2;
+      current_mram_block_addr_A &= WORD_MASK;
+      
       // Boundary check
       if(current_mram_block_addr_A < (start_mram_block_addr_A + BLOCK_SIZE))
       {
@@ -148,16 +149,12 @@ int main_kernel1() {
       if(found == -2)
       {
         end_mram_block_addr_A     = current_mram_block_addr_A;
-        current_mram_block_addr_A = (current_mram_block_addr_A + start_mram_block_addr_A) / 2;
-        current_mram_block_addr_A &= WORD_MASK;
       }
 
       // If found == -1, we need to discard left part of the input vector
       else if (found == -1)
       {
         start_mram_block_addr_A   = current_mram_block_addr_A;
-        current_mram_block_addr_A = (current_mram_block_addr_A + end_mram_block_addr_A) / 2;
-        current_mram_block_addr_A &= WORD_MASK;
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PrIM provides a common set of workloads to evaluate the UPMEM PIM architecture w
 The workloads have different characteristics, exhibiting heterogeneity in their memory access patterns, operations and data types, and communication patterns. 
 This repository also contains baseline CPU and GPU implementations of PrIM benchmarks for comparison purposes. 
 
-PrIm also includes a set of microbenchmarks can be used to assess various architecture limits such as compute throughput and memory bandwidth.
+PrIM also includes a set of microbenchmarks can be used to assess various architecture limits such as compute throughput and memory bandwidth.
 
 ## Citation
 
@@ -149,7 +149,7 @@ Several benchmark folders (HST-S, HST-L, RED, SCAN-SSA, SCAN-RSS) contain a scri
 
 ### Microbenchmarks 
 
-Each microbenchmark folder contais a script (`run.sh`) that compiles and runs the microbenchmark for the experiments in the [paper](https://arxiv.org/pdf/2105.03814.pdf):
+Each microbenchmark folder contains a script (`run.sh`) that compiles and runs the microbenchmark for the experiments in the [paper](https://arxiv.org/pdf/2105.03814.pdf):
 
 ```sh
 cd Microbenchmarks/Arithmetic-Throughput


### PR DESCRIPTION
# Binary Search Benchmark Bug Fix

Hi SAFARI team, 

I've inspected error results while testing `binary search (BS)` benchmark on `upmemcloud4`.

## Building Configurations
I built the BS benchmark configured with 640 DPUs, where each has 16 tasklets:
```cpp
$ cd ~/prim-benchmark/BS
$ cc -o bin/bs_host host/app.c -Wall -Wextra  -g -Isupport \
  -std=c11 -O3 `dpu-pkg-config --cflags --libs dpu` \
  -DNR_TASKLETS=16 -DNR_DPUS=640 -DPROBLEM_SIZE=2
$ dpu-upmem-dpurte-clang -Wall -Wextra  -g -Isupport -O2 -DNR_TASKLETS=16 \
  -o bin/bs_dpu dpu/task.c
```

## What's the Error
I then validated the program with a number of input, and I've found that **some of them can make this program produce incorrect DPU-calculated results (i.e., different from corresonding CPU-calculated results)**. For example, I've tried `$   ./bin/bs_host -i 262144`, which is the `make test` configuration:
```cpp
$ ./bin/bs_host -i 262144
```
and I got a "[ERROR] results differ!":
```cpp
CPU Version Time (ms): 8.962333	CPU-DPU Time (ms): 626.190667	DPU Kernel Time (ms): 4.234667	
DPU-CPU Time (ms): 1.218000	[ERROR] results differ!
```

## Causes
It seems like the code in `dpu/task.c` is problematic from two aspects:
1. `current_block_addr_a` wasn't always aligned to 8 bytes before being used as the start address of `mram_read`s, and this could cause the following `mram_read`s to read unaligned data from the input array.
2. The boundary case handlings could discard some numbers obliged to be compared with `searching_for`.

> Both of the factors may result in false negatives (i.e., DPU fails to identify `searching_for` in the input array even if `searching_for` indeed exists).

## About the Commits
The commits have:
1. Made sure that `current_mram_block_addr_A` is always 8-byte aligned.
2. Modified the boundary case handlings to not overlook any numbers that should be compared with `searching_for`. (please check the commits for details)
---
Please correct me if I'm wrong, and I'm looking forward to hearing from you for further discussion. Many thanks!

Regards,
Yun-Ze Li
E-mail: p76091292@gs.ncku.edu.tw

