### PR TITLE
Microbenchmarks: create profile directory if it does not exist yet

### DIFF
--- a/Microbenchmarks/Arithmetic-Throughput/run.sh
+++ b/Microbenchmarks/Arithmetic-Throughput/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in ADD SUB MUL DIV
 do
 	for j in INT32 FLOAT UINT32 INT64 DOUBLE UINT64

--- a/Microbenchmarks/CPU-DPU/run.sh
+++ b/Microbenchmarks/CPU-DPU/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in 1 2 4 8 16 32 64 
 do
 	for j in 1 

--- a/Microbenchmarks/MRAM-Latency/run.sh
+++ b/Microbenchmarks/MRAM-Latency/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in 3 4 5 6 7 8 9 10 11
 do
 	for j in 1 

--- a/Microbenchmarks/Operational-Intensity/run.sh
+++ b/Microbenchmarks/Operational-Intensity/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in ADD SUB MUL DIV
 do
 	for j in CHAR SHORT INT32 FLOAT INT64 DOUBLE

--- a/Microbenchmarks/Random-GUPS/run.sh
+++ b/Microbenchmarks/Random-GUPS/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in 1 
 do
 	for j in 1 2 4 8 12 16 

--- a/Microbenchmarks/STREAM/run.sh
+++ b/Microbenchmarks/STREAM/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 # MRAM
 for i in copy copyw add scale triad
 do

--- a/Microbenchmarks/STRIDED/run.sh
+++ b/Microbenchmarks/STRIDED/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 for i in COARSECOARSE FINEFINE
 do
 	for j in 1 

--- a/Microbenchmarks/WRAM/run.sh
+++ b/Microbenchmarks/WRAM/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p profile
+
 # WRAM
 for i in streaming random
 do


### PR DESCRIPTION
A fresh clone of the prim-benchmarks repository does not contain "profile" directories in the individual microbenchmarks, causing `run.sh` to fail. This PR adds an `mkdir -p` call to each script to handle that.